### PR TITLE
Allow emails command to output all addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ This command reads the enriched CSV (must include `projekt` and `measure` column
 topusers emails \
   --ifile enriched_list_of_topusers.csv \   # CSV with an 'Email address' column
   --ofile emails.txt \                     # output file for semicolon-separated list
-  -n 50                                    # number of top email addresses to extract
+  -n 50                                    # optionally limit the number of addresses
 ```
 
-This command reads the enriched CSV (must include an 'Email address' column), filters out any email addresses whose domain contains "lrz", and writes the top N email addresses as a semicolon-separated list to the output file.
+This command reads the enriched CSV (must include an 'Email address' column), filters out any email addresses whose domain contains "lrz", and writes the email addresses as a semicolon-separated list to the output file. Include `-n` to limit the output to the first N addresses, or omit it to include them all.
 
 ---
 

--- a/src/topusers/cli.py
+++ b/src/topusers/cli.py
@@ -283,10 +283,14 @@ def cmd_enrich(args: argparse.Namespace) -> None:
     sys.stderr.write(f"[enrich] wrote {outfile}\n")
     
 def cmd_emails(args: argparse.Namespace) -> None:
-    """Extract top N email addresses from enriched CSV, skipping LRZ addresses."""
+    """Extract top N (or all) email addresses from enriched CSV, skipping LRZ addresses."""
     infile = Path(args.ifile).expanduser()
     outfile = Path(args.ofile).expanduser()
     emails: list[str] = []
+    limit = getattr(args, "n", None)
+    if limit is not None and limit <= 0:
+        sys.stderr.write("[emails] error: -n must be a positive integer\n")
+        sys.exit(1)
     # Read input CSV and collect emails
     with infile.open('r', encoding='utf-8', newline='') as fh:
         reader = csv.DictReader(fh)
@@ -302,7 +306,7 @@ def cmd_emails(args: argparse.Namespace) -> None:
             if len(parts) == 2 and 'lrz' in parts[1].lower():
                 continue
             emails.append(email)
-            if len(emails) >= args.n:
+            if limit is not None and len(emails) >= limit:
                 break
     # Write output as semicolon-separated list
     with outfile.open('w', encoding='utf-8') as fh:
@@ -461,8 +465,7 @@ def build_parser() -> argparse.ArgumentParser:
         "-n",
         dest="n",
         type=int,
-        required=True,
-        help="number of top email addresses to extract"
+        help="number of top email addresses to extract (omit to include all)"
     )
     pe2.set_defaults(func=cmd_emails)
     # aggregate_groups: sum measures per project from enriched CSV


### PR DESCRIPTION
## Summary
- allow the `topusers emails` command to collect all email addresses when `-n` is omitted
- add a guard against non-positive limits and refresh the CLI help text
- update the README to document the optional `-n` flag

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da921f1eac832585c469424e4d64c2